### PR TITLE
Get away from master/slave words

### DIFF
--- a/agent/lib2/zone_operate.py
+++ b/agent/lib2/zone_operate.py
@@ -84,7 +84,7 @@ class Zone:
 # if __name__ == '__main__':
 #     zone_template = "/tmp/pycharm_project_682/agent/conf/default_template_zone.zone"
 #     a = Zone(zone_template)
-#     print(a.add_zone("shanghai", "xiaoxin.cc", "xiaoxin.cc.zone", '{type master; file "xiaoxin.cc.zone"; allow-update {key golet;};};'))
+#     print(a.add_zone("shanghai", "xiaoxin.cc", "xiaoxin.cc.zone", '{type main; file "xiaoxin.cc.zone"; allow-update {key golet;};};'))
 #     a.del_zone("beijing", "xiaoxin.cc", "xiaoxin.cc.zone")
     # a.create_zone_file("dasda")
     # a.del_zone("beijing", "dasda", "")

--- a/agent/management/commands/view.py
+++ b/agent/management/commands/view.py
@@ -52,12 +52,12 @@ class Command(BaseCommand):
                 name, key, dns_type = options["value"]
             except ValueError:
                 raise CommandError("缺少参数!")
-            if dns_type.strip() == "master":
+            if dns_type.strip() == "main":
                 dns_type = 1
-            elif dns_type.strip() == "slave":
+            elif dns_type.strip() == "subordinate":
                 dns_type = 2
             else:
-                raise CommandError("dns_type错误, 目前支持[master, slave]")
+                raise CommandError("dns_type错误, 目前支持[main, subordinate]")
             self.add_view(name, key, dns_type)
         elif options.get("list"):
 

--- a/agent/migrations/0001_initial.py
+++ b/agent/migrations/0001_initial.py
@@ -49,7 +49,7 @@ class Migration(migrations.Migration):
                 ('view_name', models.CharField(help_text='视图名称', max_length=120, unique=True)),
                 ('key_name', models.CharField(help_text='视图所有使用的Key名称', max_length=120)),
                 ('code_name', models.CharField(help_text='视图所有使用密钥', max_length=120)),
-                ('type', models.IntegerField(choices=[(1, 'master'), (2, 'slave')], default=1, help_text='服务类型')),
+                ('type', models.IntegerField(choices=[(1, 'main'), (2, 'subordinate')], default=1, help_text='服务类型')),
                 ('create_time', models.DateTimeField(auto_now_add=True, help_text='创建时间')),
                 ('update_time', models.DateTimeField(auto_now=True, help_text='更新时间')),
                 ('is_register', models.BooleanField(default=False, help_text='是否注册到服务端')),

--- a/agent/models.py
+++ b/agent/models.py
@@ -3,8 +3,8 @@ from django.db import models
 
 class AgentViewModels(models.Model):
     TYPE_CHOICES = (
-        (1, "master"),
-        (2, "slave"),
+        (1, "main"),
+        (2, "subordinate"),
     )
     view_name = models.CharField(max_length=120, unique=True, verbose_name="视图名称")
     key_name = models.CharField(max_length=120, verbose_name="视图所有使用的Key名称")

--- a/agent/views.py
+++ b/agent/views.py
@@ -86,7 +86,7 @@ class DomainView(views_tools.Domain, viewsets.GenericViewSet):
             view_obj.domain.get(domain_name=domain_name)
         except models.AgentDomainModels.DoesNotExist:
             # 如果zone_file不存在则创建一个新的文件
-            # '{type master; file "$zone_file"; allow-update {key $code;};};' zone_file 表示zone文件， safe_code 表示操作zone_key
+            # '{type main; file "$zone_file"; allow-update {key $code;};};' zone_file 表示zone文件， safe_code 表示操作zone_key
             # if not os.path.exists(zone_file) or not os.path.isfile(zone_file):
             #     return Response({"code": 2003, "msg": "文件{file}不存在".format(file=zone_file)})
             config_template = string.Template(config.strip())


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.